### PR TITLE
upd retail contract regulatory and env rates

### DIFF
--- a/schema/V47__update_retail_contract_to_remove_old_fk.sql
+++ b/schema/V47__update_retail_contract_to_remove_old_fk.sql
@@ -1,0 +1,15 @@
+ALTER TABLE [dbo].[retail_contract] DROP CONSTRAINT [FK_retail_contract_retail_tariff];
+GO
+ALTER TABLE [dbo].[retail_contract] DROP CONSTRAINT [FK_retail_contract_retailer];
+GO
+ALTER TABLE [dbo].[retail_contract] DROP CONSTRAINT [FK_retail_contract_network_tariff];
+GO
+ALTER TABLE [dbo].[retail_contract] DROP CONSTRAINT [FK_retail_contract_network_provider];
+GO
+ALTER TABLE [dbo].[retail_contract]
+DROP COLUMN [retail_tariff_id],
+            [retailer_id],
+            [network_tariff_id],
+            [network_provider_id],
+            [is_network_charges_bundled];
+GO

--- a/schema/V48__create_table_retail_contract_retail_tariff.sql
+++ b/schema/V48__create_table_retail_contract_retail_tariff.sql
@@ -1,0 +1,26 @@
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+
+CREATE TABLE [dbo].[retail_contract_retail_tariff] (
+    [id] INT NOT NULL PRIMARY KEY,
+    [company_id] INT NOT NULL,
+    [retail_contract_id] INT NOT NULL,
+    [retail_tariff_id] INT NOT NULL,
+    [created_at] DATETIME2(7) NOT NULL DEFAULT (SYSDATETIME()),
+    [updated_at] DATETIME2(7) NOT NULL DEFAULT (SYSDATETIME())
+) ON [PRIMARY]
+GO
+
+ALTER TABLE [dbo].[retail_contract_retail_tariff] ADD CONSTRAINT [FK_retail_contract_retail_tariff_company]
+FOREIGN KEY ([company_id]) REFERENCES [dbo].[company] ([id])
+GO
+
+ALTER TABLE [dbo].[retail_contract_retail_tariff] ADD CONSTRAINT [FK_retail_contract_retail_tariff_retail_contract]
+FOREIGN KEY ([retail_contract_id]) REFERENCES [dbo].[retail_contract] ([id])
+GO
+
+ALTER TABLE [dbo].[retail_contract_retail_tariff] ADD CONSTRAINT [FK_retail_contract_retail_tariff_retail_tariff]
+FOREIGN KEY ([retail_tariff_id]) REFERENCES [dbo].[retail_tariff] ([id])
+GO

--- a/schema/V49__create_table_retail_contract_network_tariff.sql
+++ b/schema/V49__create_table_retail_contract_network_tariff.sql
@@ -1,0 +1,26 @@
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+
+CREATE TABLE [dbo].[retail_contract_network_tariff] (
+    [id] INT NOT NULL PRIMARY KEY,
+    [company_id] INT NOT NULL,
+    [retail_contract_id] INT NOT NULL,
+    [network_tariff_id] INT NOT NULL,
+    [created_at] DATETIME2(7) NOT NULL DEFAULT (SYSDATETIME()),
+    [updated_at] DATETIME2(7) NOT NULL DEFAULT (SYSDATETIME())
+) ON [PRIMARY]
+GO
+
+ALTER TABLE [dbo].[retail_contract_network_tariff] ADD CONSTRAINT [FK_retail_contract_network_tariff_company]
+FOREIGN KEY ([company_id]) REFERENCES [dbo].[company] ([id])
+GO
+
+ALTER TABLE [dbo].[retail_contract_network_tariff] ADD CONSTRAINT [FK_retail_contract_network_tariff_retail_contract]
+FOREIGN KEY ([retail_contract_id]) REFERENCES [dbo].[retail_contract] ([id])
+GO
+
+ALTER TABLE [dbo].[retail_contract_network_tariff] ADD CONSTRAINT [FK_retail_contract_network_tariff_network_tariff]
+FOREIGN KEY ([network_tariff_id]) REFERENCES [dbo].[network_tariff] ([id])
+GO

--- a/schema/V50__delete_table_retail_contract_history.sql
+++ b/schema/V50__delete_table_retail_contract_history.sql
@@ -1,0 +1,11 @@
+ALTER TABLE [dbo].[retail_contract_history] DROP CONSTRAINT [FK_retail_contract_history_company];
+GO
+
+ALTER TABLE [dbo].[retail_contract_history] DROP CONSTRAINT [FK_retail_contract_history_retail_contract];
+GO
+
+ALTER TABLE [dbo].[retail_contract_history] DROP CONSTRAINT [PK_retail_contract_history];
+GO
+
+DROP TABLE [dbo].[retail_contract_history];
+GO

--- a/schema/V51__create_table_retail_contract_retail_tariff_history.sql
+++ b/schema/V51__create_table_retail_contract_retail_tariff_history.sql
@@ -1,0 +1,26 @@
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+
+CREATE TABLE [dbo].[retail_contract_retail_tariff_history] (
+    [id] INT NOT NULL PRIMARY KEY,
+    [company_id] INT NOT NULL,
+    [retail_contract_id] INT NOT NULL,
+    [retail_tariff_id] INT NOT NULL,
+    [created_at] DATETIME2(7) NOT NULL DEFAULT (SYSDATETIME()),
+    [updated_at] DATETIME2(7) NOT NULL DEFAULT (SYSDATETIME())
+) ON [PRIMARY]
+GO
+
+ALTER TABLE [dbo].[retail_contract_retail_tariff_history] ADD CONSTRAINT [FK_retail_contract_retail_tariff_history_company]
+FOREIGN KEY ([company_id]) REFERENCES [dbo].[company] ([id])
+GO
+
+ALTER TABLE [dbo].[retail_contract_retail_tariff_history] ADD CONSTRAINT [FK_retail_contract_retail_tariff_retail_history_contract]
+FOREIGN KEY ([retail_contract_id]) REFERENCES [dbo].[retail_contract] ([id])
+GO
+
+ALTER TABLE [dbo].[retail_contract_retail_tariff_history] ADD CONSTRAINT [FK_retail_contract_retail_tariff_retail_history_tariff]
+FOREIGN KEY ([retail_tariff_id]) REFERENCES [dbo].[retail_tariff] ([id])
+GO

--- a/schema/V52__create_table_retail_contract_network_tariff_history.sql
+++ b/schema/V52__create_table_retail_contract_network_tariff_history.sql
@@ -1,0 +1,26 @@
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+
+CREATE TABLE [dbo].[retail_contract_network_tariff_history] (
+    [id] INT NOT NULL PRIMARY KEY,
+    [company_id] INT NOT NULL,
+    [retail_contract_id] INT NOT NULL,
+    [network_tariff_id] INT NOT NULL,
+    [created_at] DATETIME2(7) NOT NULL DEFAULT (SYSDATETIME()),
+    [updated_at] DATETIME2(7) NOT NULL DEFAULT (SYSDATETIME())
+) ON [PRIMARY]
+GO
+
+ALTER TABLE [dbo].[retail_contract_network_tariff_history] ADD CONSTRAINT [FK_retail_contract_network_tariff_history_company]
+FOREIGN KEY ([company_id]) REFERENCES [dbo].[company] ([id])
+GO
+
+ALTER TABLE [dbo].[retail_contract_network_tariff_history] ADD CONSTRAINT [FK_retail_contract_network_tariff_history_contract]
+FOREIGN KEY ([retail_contract_id]) REFERENCES [dbo].[retail_contract] ([id])
+GO
+
+ALTER TABLE [dbo].[retail_contract_network_tariff_history] ADD CONSTRAINT [FK_retail_contract_network_tariff_network_history_tariff]
+FOREIGN KEY ([network_tariff_id]) REFERENCES [dbo].[network_tariff] ([id])
+GO

--- a/schema/V53__create_table_regulatory_environmental_rate.sql
+++ b/schema/V53__create_table_regulatory_environmental_rate.sql
@@ -1,0 +1,22 @@
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TABLE [dbo].[regulatory_environmental_rate](
+	[id] INT NOT NULL PRIMARY KEY,
+    [state] [varchar](50) NOT NULL,
+	[type] [varchar](50) NOT NULL,
+	[rate] [float] NULL,
+	[start_date] [date] NULL,
+	[end_date] [date] NULL,
+	[created_at] [datetime2](7) NOT NULL DEFAULT (SYSDATETIME()),
+    [updated_at] [datetime2](7) NOT NULL DEFAULT (SYSDATETIME())
+) ON [PRIMARY]
+GO
+ALTER TABLE [dbo].[regulatory_environmental_rate]  WITH CHECK ADD CONSTRAINT [CHK_re_type_values] CHECK ([type] IN ('regulatory', 'environmental'));
+GO
+ALTER TABLE [dbo].[regulatory_environmental_rate] CHECK CONSTRAINT [CHK_re_type_values]
+GO
+ALTER TABLE [dbo].[regulatory_environmental_rate]
+ADD CONSTRAINT CHK_regulatory_environmental_rate_start_date_lt_end_date CHECK ([start_date] < [end_date]);
+GO

--- a/schema/V54__create_table_regulatory_environmental_company.sql
+++ b/schema/V54__create_table_regulatory_environmental_company.sql
@@ -1,0 +1,21 @@
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+
+CREATE TABLE [dbo].[regulatory_environmental_company] (
+    [id] INT NOT NULL PRIMARY KEY,
+    [company_id] INT NOT NULL,
+    [regulatory_environmental_rate_id] INT NOT NULL,
+    [created_at] DATETIME2(7) NOT NULL DEFAULT (SYSDATETIME()),
+    [updated_at] DATETIME2(7) NOT NULL DEFAULT (SYSDATETIME())
+) ON [PRIMARY]
+GO
+
+ALTER TABLE [dbo].[regulatory_environmental_company] ADD CONSTRAINT [FK_regulatory_environmental_company]
+FOREIGN KEY ([company_id]) REFERENCES [dbo].[company] ([id])
+GO
+
+ALTER TABLE [dbo].[regulatory_environmental_company] ADD CONSTRAINT [FK_regulatory_environmental_company_rate_id]
+FOREIGN KEY ([regulatory_environmental_rate_id]) REFERENCES [dbo].[regulatory_environmental_rate] ([id])
+GO


### PR DESCRIPTION
Updates:

1. **Retail Contract -> retail tariff & network tariff redesign**
Instead of 1:1 relationship of retail contract and tariffs, we change it to many to many
2. **Updated Retail Contract history**
From having only one history of retail contract, now there are exclusive history for retail and network tariff due to many to many
design. Retail Tariff History and Network Tariff History
3. **Added Regulatory and environmental rates**

Documentation: https://birdwoodbusinessenergy.atlassian.net/wiki/spaces/ABP/pages/83853313/Retail+-+Network+-+PPA+-+Regulatory+-+Environmental+Documentation


![final-rates-erd](https://github.com/user-attachments/assets/5b62a05a-40c6-4257-a8d8-904e05e0c7fe)

